### PR TITLE
remove dependency version requirements

### DIFF
--- a/wayback.gemspec
+++ b/wayback.gemspec
@@ -4,9 +4,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'wayback/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['~> 0.8', '< 0.10']
-  spec.add_dependency 'faraday_middleware', ['~> 0.9', '< 0.10']
-  spec.add_dependency 'json', '~> 1.8'
+  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday_middleware'
+  spec.add_dependency 'json'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ["Greg Leuch"]
   # spec.cert_chain  = ['certs/gleuch.pem']


### PR DESCRIPTION
Forked this gem because it is not being actively supported and requires a vulnerable version of `json`. This PR removes the version requirements and will allow us to upgrade `json`.